### PR TITLE
Move tokio to dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,6 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.59"
 bitflags = "1.3.2"
+
+[dev-dependencies]
 tokio = { version = "1.23.0", features = ["time", "rt", "macros"] }


### PR DESCRIPTION
This should optimize build times outside of tests a bit.