### PR TITLE
Skip testing on macos for Python 3.7 due to it no longer being supported.

### DIFF
--- a/.github/workflows/test_suite_python.yml
+++ b/.github/workflows/test_suite_python.yml
@@ -45,6 +45,10 @@ jobs:
           - "3.11"
           - "3.12"
           - "3" # Latest version
+        exclude:
+          # Skip Python 3.7 on macos-latest due to no support.
+          - os: macos-latest
+            python-version: "3.7"
     runs-on: ${{matrix.os}}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
See Remove Python 3.7 support #210

Signed-off-by: Scott Wilson <scott@propersquid.com>